### PR TITLE
Fixed duplicate cors header

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/cors.conf
+++ b/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/cors.conf
@@ -15,6 +15,10 @@
 # Forked from this Gist: https://gist.github.com/michiel/1064640
 #
 
+# do not send duplicate origin headers if the underlying
+# service is CORS-compliant
+proxy_hide_header 'Access-Control-Allow-Origin';
+
 set $cors_method '';
 
 if ($request_method = 'GET') {
@@ -48,6 +52,4 @@ if ($cors_method = 'noopt') {
     add_header 'Access-Control-Allow-Credentials' 'true' always;
     add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
     add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With' always;
-    # required to be able to read Authorization header in frontend
-    #add_header 'Access-Control-Expose-Headers' 'Authorization' always;
 }


### PR DESCRIPTION
Should fix RADAR-base/ManagementPortal#258, by hiding any `Access-Control-Allow-Origin` sent by the proxied service if CORS is enabled in Nginx.