### PR TITLE
Tweak command scripts

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/bin/docker-prune
+++ b/dcompose-stack/radar-cp-hadoop-stack/bin/docker-prune
@@ -13,6 +13,7 @@ select yn in "Yes" "No"; do
     Yes ) sudo-linux docker system prune --filter "label!=certs" "$@";
           sudo-linux rm -rf "$HDFS_DATA_DIR_1";
           sudo-linux rm -rf "$HDFS_DATA_DIR_2";
+          sudo-linux rm -rf "$HDFS_DATA_DIR_3";
           sudo-linux rm -rf "$HDFS_NAME_DIR_1";
           sudo-linux rm -rf "$HDFS_NAME_DIR_2";
           sudo-linux rm -rf "$MONGODB_DIR";

--- a/dcompose-stack/radar-cp-hadoop-stack/bin/radar-docker
+++ b/dcompose-stack/radar-cp-hadoop-stack/bin/radar-docker
@@ -52,7 +52,7 @@ install-systemd)
   . lib/install-systemd-wrappers.sh
   ;;
 rebuild)
-  exec $stack up -d --force-recreate --build -V "$@"
+  exec $stack up -d --force-recreate --build --no-deps -V "$@"
   ;;
 quit)
   $stack stop "$@" && \


### PR DESCRIPTION
- Also remove third HDFS data node on prune
- Do not recreate dependent services after `radar-docker rebuild SERVICE...`
