### PR TITLE
Only snapshot updated files and check zip integrity

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/bin/hdfs-restructure
+++ b/dcompose-stack/radar-cp-hadoop-stack/bin/hdfs-restructure
@@ -101,16 +101,27 @@ function create_snapshots() {
     SNAPSHOT=$SNAPSHOT_DIR/$month.zip
     SNAPSHOT_TMP=$SNAPSHOT_TMP_DIR/$month.zip
     if [ -e $SNAPSHOT ]; then
-      find . -name "$month[0-9][0-9]_[0-9][0-9][0-9][0-9].*" | zip -0@u $SNAPSHOT -O $SNAPSHOT_TMP
-      if [ -e $SNAPSHOT_TMP ]; then
-        mv $SNAPSHOT_TMP $SNAPSHOT
+      UPDATED_FILES_TMP=$SNAPSHOT_TMP.updated
+      find . -name "$month[0-9][0-9]_[0-9][0-9][0-9][0-9].*" -newer $SNAPSHOT > $UPDATED_FILES_TMP
+      if [ ! -s $UPDATED_FILES_TMP ]; then
+        # No new files for this snapshot
+        continue
       fi
-    else
-      find . -name "$month[0-9][0-9]_[0-9][0-9][0-9][0-9].*" | zip -0@ $SNAPSHOT_TMP
-      mv $SNAPSHOT_TMP $SNAPSHOT
+      if zip -T $SNAPSHOT >/dev/null; then
+        zip -0@u $SNAPSHOT -O $SNAPSHOT_TMP < $UPDATED_FILES_TMP
+        rm $UPDATED_FILES_TMP
+        if [ -e $SNAPSHOT_TMP ]; then
+          mv $SNAPSHOT_TMP $SNAPSHOT
+        fi
+        continue
+      else
+        echo "Snapshot for ${project}/${month}.zip was corrupted. Recreating."
+        rm $SNAPSHOT
+      fi
     fi
+    find . -name "$month[0-9][0-9]_[0-9][0-9][0-9][0-9].*" | zip -0@ $SNAPSHOT_TMP
+    mv $SNAPSHOT_TMP $SNAPSHOT
   done
-  cd "$OLDPWD"
 }
 
 export -f create_snapshots


### PR DESCRIPTION
Issues fixed:
- Corrupted zip files were not updated anymore. Recreating when this occurs
- Optimisation to only process files that were updated more recently than the snapshot