### PR TITLE
feat(stack): add NetData to the stack, no auth yet

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -631,6 +631,27 @@ services:
       TOPIC_LIST: "application_record_counts"
 
   #---------------------------------------------------------------------------#
+  # NetData Host Monitoring                                                   #
+  #---------------------------------------------------------------------------#
+  netdata:
+    image: netdata/netdata
+    #networks:
+    #  - 
+    hostname: netdata # set to fqdn of host
+    ports:
+      - 19999:19999
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    environment:
+      PGID=999
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  #---------------------------------------------------------------------------#
   # Docker Monitoring                                                         #
   #---------------------------------------------------------------------------#
   portainer:

--- a/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/nginx.conf.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/nginx.conf.template
@@ -95,6 +95,10 @@ http {
       proxy_pass         http://portainer:9000/;
       proxy_http_version 1.1;
       proxy_set_header   Connection "";
+      #should be restricted
+      #allow your-subnet1;
+      #allow your-subnet2;
+      #deny all;
     }
     location /portainer/api/websocket/ {
       include ip-access-control.conf;
@@ -125,6 +129,14 @@ http {
       include cors.conf;
       proxy_pass         http://managementportal-app:8080/managementportal/api/meta-token/;
       proxy_set_header   Host $host;
+    }
+    location /netdata/ {
+      proxy_pass	http://netdata:19999/;
+      #should be restricted
+      #allow your-subnet1;
+      #allow your-subnet2;
+      #deny all;
+      
     }
     location /kafkamanager/{
       include ip-access-control.conf;


### PR DESCRIPTION
Started looking at server monitoring to the stack via NetData container  #132  
- [x]  docker compose with options to access the docker group (default I think is 999 but this may need to be a param)
- [ ] missing auth
