### PR TITLE
Fix replication factor

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -279,8 +279,8 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
       KAFKA_SCHEMA_REGISTRY: http://schema-registry-1:8081
       KAFKA_NUM_BROKERS: 3
-      RADAR_NUM_PARTITIONS: 3
-      RADAR_NUM_REPLICATION_FACTOR: 3
+      KAFKA_NUM_PARTITIONS: 3
+      KAFKA_NUM_REPLICATION: 3
 
   #---------------------------------------------------------------------------#
   # RADAR Hot Storage                                                         #


### PR DESCRIPTION
The variables for kafka-init in docker-compose were not the ones used in the Dockerfile. Changed them to their actual values.

This will not affect existing topics though. To change the replication factor of existing topics, based on a comment from Stackoverflow, the following should work:

```bash
docker-compose exec kafka-1 /bin/bash

function expandTopicsFrom2To3() {
  TOPIC=$1
  echo '{"version":1,"partitions":[{"topic":"'${TOPIC}'","partition":0,"replicas":[1,2,3]},{"topic":"'${TOPIC}'","partition":2,"replicas":[1,2,3]},{"topic":"'${TOPIC}'","partition":1,"replicas":[1,2,3]}]}' > /tmp/topics-to-expand.json
  kafka-reassign-partitions --zookeeper zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --execute --reassignment-json-file /tmp/topics-to-expand.json
  kafka-topics --zookeeper zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --describe --topic ${TOPIC}
}

expandTopicsFrom2To3 questionnaire_esm
```