### PR TITLE
update portainer version

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -636,7 +636,7 @@ services:
   # Docker Monitoring                                                         #
   #---------------------------------------------------------------------------#
   portainer:
-    image: portainer/portainer:1.19.1
+    image: portainer/portainer:1.22.0
     command: --admin-password '${PORTAINER_PASSWORD_HASH}'
     networks:
       - monitor

--- a/dcompose-stack/radar-cp-hadoop-stack/lib/systemd/radar-renew-certificate.timer.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/lib/systemd/radar-renew-certificate.timer.template
@@ -6,7 +6,7 @@ BindsTo=radar-docker.service
 OnCalendar=daily
 RandomizedDelaySec=12h
 Persistent=true
-Unit=radar-check-health.service
+Unit=radar-renew-certificate.service
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Portainer version 1.19.1 is not available on docker hub anymore. So update to the latest version.