### PR TITLE
Use ACME protocol v2 for lets encrypt certificate

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/lib/util.sh
+++ b/dcompose-stack/radar-cp-hadoop-stack/lib/util.sh
@@ -143,7 +143,7 @@ letsencrypt_certonly() {
   sudo-linux docker run --rm -v certs:/etc/openssl alpine:3.7 /bin/sh -c "find /etc/openssl -name '${SERVER_NAME}*' -prune -exec rm -rf '{}' +"
 
   CERTBOT_DOCKER_OPTS=(--rm -v certs:/etc/letsencrypt -v certs-data:/data/letsencrypt deliverous/certbot)
-  CERTBOT_OPTS=(--webroot --webroot-path=/data/letsencrypt --agree-tos -m "${MAINTAINER_EMAIL}" -d "${SERVER_NAME}" --non-interactive)
+  CERTBOT_OPTS=(--server "https://acme-v02.api.letsencrypt.org/directory" --webroot --webroot-path=/data/letsencrypt --agree-tos -m "${MAINTAINER_EMAIL}" -d "${SERVER_NAME}" --non-interactive)
   sudo-linux docker run "${CERTBOT_DOCKER_OPTS[@]}" certonly "${CERTBOT_OPTS[@]}"
 
   # mark the directory as letsencrypt dir
@@ -154,7 +154,7 @@ letsencrypt_renew() {
   SERVER_NAME=$1
   echo "==> Renewing Let's Encrypt SSL certificate for ${SERVER_NAME}"
   CERTBOT_DOCKER_OPTS=(--rm -v certs:/etc/letsencrypt -v certs-data:/data/letsencrypt deliverous/certbot)
-  CERTBOT_OPTS=(-n --webroot --webroot-path=/data/letsencrypt -d "${SERVER_NAME}" --non-interactive)
+  CERTBOT_OPTS=(-n --server "https://acme-v02.api.letsencrypt.org/directory" --webroot --webroot-path=/data/letsencrypt -d "${SERVER_NAME}" --non-interactive)
   sudo-linux docker run "${CERTBOT_DOCKER_OPTS[@]}" certonly "${CERTBOT_OPTS[@]}"
 }
 

--- a/images/hsqldb/Dockerfile
+++ b/images/hsqldb/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p /opt/hsqldb/lib /etc/opt/hsqldb/conf /var/opt/hsqldb/data && \
     useradd --system -g hsqldb -u 9999 hsqldb && \
     chown hsqldb:hsqldb -R /var/opt/hsqldb
 
-ENV MVN_CENTRAL_URL http://central.maven.org/maven2
+ENV MVN_CENTRAL_URL https://repo1.maven.org/maven2/
 ENV HSQLDB_MVN_GRP org/hsqldb
 ENV HSQLDB_VERSION 2.5.0
 ENV LOG4J_VERSION 1.2.17


### PR DESCRIPTION
Version 1 is deprecated and will stop working after 1 June, 2020

Certbot ref: https://certbot.eff.org/docs/using.html?highlight=hook#changing-the-acme-server 