### PR TITLE
Use correct zookeeper log directory

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
+++ b/dcompose-stack/radar-cp-hadoop-stack/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - zookeeper
     volumes:
       - zookeeper-1-data:/var/lib/zookeeper/data
-      - zookeeper-1-log:/var/lib/zookeeper/logs
+      - zookeeper-1-log:/var/lib/zookeeper/log
     restart: always
     environment:
       ZOOKEEPER_SERVER_ID: 1
@@ -75,7 +75,7 @@ services:
       - zookeeper
     volumes:
       - zookeeper-2-data:/var/lib/zookeeper/data
-      - zookeeper-2-log:/var/lib/zookeeper/logs
+      - zookeeper-2-log:/var/lib/zookeeper/log
     restart: always
     environment:
       ZOOKEEPER_SERVER_ID: 2
@@ -96,7 +96,7 @@ services:
       - zookeeper
     volumes:
       - zookeeper-3-data:/var/lib/zookeeper/data
-      - zookeeper-3-log:/var/lib/zookeeper/logs
+      - zookeeper-3-log:/var/lib/zookeeper/log
     restart: always
     environment:
       ZOOKEEPER_SERVER_ID: 3


### PR DESCRIPTION
Apparently, zookeeper logs were never correctly persisted. Note that this update will trigger a restart of the stack on the next install.

This issue was deduced via a separate issue noticed by @nivemaham that Kafka 2.4 would no longer start after a restart because Zookeeper did not persist its cluster ID.