### PR TITLE
Nginx security fixes

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/nginx.conf.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/nginx.conf.template
@@ -45,7 +45,7 @@ http {
     ssl_session_cache         shared:SSL:20m;
     ssl_session_timeout       10m;
 
-    ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols             TLSv1.2;
     ssl_prefer_server_ciphers on;
     ssl_ciphers               "ECDH+AESGCM:ECDH+AES256:ECDH+AES128:!ADH:!AECDH:!MD5;";
 
@@ -86,6 +86,7 @@ http {
         add_header 'Access-Control-Max-Age' 1728000;
         add_header 'Content-Type' 'text/plain charset=UTF-8';
         add_header 'Content-Length' 0;
+        add_header 'Allow' 'GET,OPTIONS';
         return 204;
       }
 
@@ -103,6 +104,9 @@ http {
       proxy_set_header   Host $host;
       proxy_http_version 1.1;
       proxy_set_header   Connection "";
+    }
+    location = /schema/application.wadl {
+      deny all;
     }
     location /dashboard/ {
       proxy_pass         http://dashboard:80/;

--- a/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/nginx.nossl.conf.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/etc/webserver/nginx.nossl.conf.template
@@ -17,6 +17,9 @@ http {
     '"$http_user_agent" "$http_x_forwarded_for"';
   tcp_nodelay  on;
 
+  # hide nginx version
+  server_tokens off;
+
   # add nosniff header (https://www.owasp.org/index.php/List_of_useful_HTTP_headers)
   add_header X-Content-Type-Options nosniff;
 
@@ -57,6 +60,7 @@ http {
         add_header 'Access-Control-Max-Age' 1728000;
         add_header 'Content-Type' 'text/plain charset=UTF-8';
         add_header 'Content-Length' 0;
+        add_header 'Allow' 'GET,OPTIONS';
         return 204;
       }
 
@@ -74,6 +78,9 @@ http {
       proxy_set_header   Host $host;
       proxy_http_version 1.1;
       proxy_set_header   Connection "";
+    }
+    location = /schema/application.wadl {
+      deny all;
     }
     location /dashboard/ {
       proxy_pass         http://dashboard:80/;


### PR DESCRIPTION
Small security fixes. Especially phasing out TLS 1.0 and 1.1 is important, they have been declared EOL long ago and are starting to generate warnings.

Edit: may also be applied to #218 if accepted.