### PR TITLE
Remove stale volumes

### DIFF
--- a/dcompose-stack/radar-cp-hadoop-stack/lib/systemd/radar-docker.service.template
+++ b/dcompose-stack/radar-cp-hadoop-stack/lib/systemd/radar-docker.service.template
@@ -17,7 +17,7 @@ ExecStart=./lib/systemd/start-radar-stack.sh
 
 ExecReload=/usr/local/bin/docker-compose restart
 
-ExecStop=/usr/local/bin/docker-compose down
+ExecStop=/usr/local/bin/docker-compose down -v
 
 NotifyAccess=all
 


### PR DESCRIPTION
Remove volumes after a restart of the radar-docker stack. This avoids the disk filling up when the stack is restarting continuously.